### PR TITLE
Rename bro-vast to zeek-vast

### DIFF
--- a/tenzir/bro-pkg.index
+++ b/tenzir/bro-pkg.index
@@ -1,1 +1,1 @@
-https://github.com/tenzir/bro-vast
+https://github.com/tenzir/zeek-vast


### PR DESCRIPTION
This PR renames the *bro-vast* package to *zeek-vast*.