### PR TITLE
added dovehawk passive dns collector

### DIFF
--- a/dovehawk/bro-pkg.index
+++ b/dovehawk/bro-pkg.index
@@ -1,1 +1,2 @@
 https://github.com/tylabs/dovehawk
+https://github.com/tylabs/dovehawk_dns


### PR DESCRIPTION
New module to collect passive DNS to a central database for historical threat hunting.