### PR TITLE
Add MAC ages plugin

### DIFF
--- a/tenzir/bro-pkg.index
+++ b/tenzir/bro-pkg.index
@@ -1,1 +1,2 @@
+https://github.com/tenzir/zeek-mac-ages
 https://github.com/tenzir/zeek-vast


### PR DESCRIPTION
This PR adds a plugin for Tenzir's [Zeek MAC ages](https://github.com/tenzir/zeek-mac-ages) plugin.