### PR TITLE
Add zkg.index file for packages being released in the `amzn` org

### DIFF
--- a/amzn/zkg.index
+++ b/amzn/zkg.index
@@ -1,0 +1,5 @@
+https://github.com/amzn/zeek-plugin-bacnet
+https://github.com/amzn/zeek-plugin-enip
+https://github.com/amzn/zeek-plugin-profinet
+https://github.com/amzn/zeek-plugin-s7comm
+https://github.com/amzn/zeek-plugin-tds


### PR DESCRIPTION
As announced earlier on the `zeek-dev` email list, as part of our work on the Customer Fulfillment Technology Security team at Amazon.com we've developed a set of protocol parsers for industrial control systems devices that we use in our production Zeek deployment.

This PR adds five plugins for protocol analyzers to the package index.