### PR TITLE
Simple policy to detect Apple 3283/udp DoS attack Candidate

### DIFF
--- a/initconf/bro-pkg.index
+++ b/initconf/bro-pkg.index
@@ -6,3 +6,4 @@ https://github.com/initconf/blacklist
 https://github.com/initconf/vnc-scanner
 https://github.com/initconf/ftp-bruteforce
 https://github.com/initconf/detect-kaspersky
+https://github.com/initconf/ws-discovery-dos

--- a/initconf/bro-pkg.index
+++ b/initconf/bro-pkg.index
@@ -7,3 +7,4 @@ https://github.com/initconf/vnc-scanner
 https://github.com/initconf/ftp-bruteforce
 https://github.com/initconf/detect-kaspersky
 https://github.com/initconf/ws-discovery-dos
+https://github.com/initconf/Apple-RDP-net-assistant-DoS.git


### PR DESCRIPTION
new package : Simple policy to detect ws-discovery DNS amplification attack