### PR TITLE
Migrate the Community ID package to the zkg era

### DIFF
--- a/corelight/bro-pkg.index
+++ b/corelight/bro-pkg.index
@@ -7,7 +7,6 @@ https://github.com/corelight/conn-burst
 https://github.com/corelight/log-add-http-post-bodies
 https://github.com/corelight/log-add-vlan-everywhere
 https://github.com/corelight/top-dns
-https://github.com/corelight/bro-community-id
 https://github.com/corelight/json-streaming-logs
 https://github.com/corelight/http-stalling-detector
 https://github.com/corelight/bro-quic

--- a/corelight/zkg.index
+++ b/corelight/zkg.index
@@ -1,3 +1,4 @@
+https://github.com/corelight/zeek-community-id
+https://github.com/corelight/zeek-elf
 https://github.com/corelight/zeek-jpeg
 https://github.com/corelight/zeek-macho
-https://github.com/corelight/zeek-elf


### PR DESCRIPTION
This reflects the 3.1-era Zeekification of the Community ID package, with its repository renaming. Technically we could leave the URL in bro-pkg.index, but it seems cleaner to make the cut. Shout if you feel that's incorrect ... thanks!