### PR TITLE
Add SMBFP package

### DIFF
--- a/micrictor/zkg.index
+++ b/micrictor/zkg.index
@@ -1,1 +1,2 @@
 https://github.com/micrictor/spl-spt
+https://github.com/micrictor/smbfp


### PR DESCRIPTION
Add SMBFP package, which will generate a fingerprint of SMB clients and add it to the existing SMB logs.