### PR TITLE
Added the Package callstranger-detector to the Corelight list

### DIFF
--- a/corelight/zkg.index
+++ b/corelight/zkg.index
@@ -3,3 +3,4 @@ https://github.com/corelight/zeek-elf
 https://github.com/corelight/zeek-jpeg
 https://github.com/corelight/zeek-macho
 https://github.com/corelight/got_zoom
+https://github.com/corelight/callstranger-detector


### PR DESCRIPTION
CallStranger is a new UPnP vulnerability and the callstranger-detector is a Zeek plugin that helps detect it. See the full info at https://github.com/corelight/callstranger-detector or https://corelight.blog/2020/06/10/detecting-the-new-callstranger-upnp-vulnerability-with-zeek/