### PR TITLE
Start a brimsec/zkg.index with geoip-conn package

### DIFF
--- a/brimsec/zkg.index
+++ b/brimsec/zkg.index
@@ -1,0 +1,1 @@
+https://github.com/brimsec/geoip-conn


### PR DESCRIPTION
After a [Slack thread](https://zeekorg.slack.com/archives/CSZBXF6TH/p1594235715230000) I put together a Zeek package to populate GeoLocation data into `conn` records, as we've had interest from the community about offering this as a default behavior in the [Brim](https://github.com/brimsec/brim) app.