### PR TITLE
add CIF package to index

### DIFF
--- a/sfinlon/zkg.index
+++ b/sfinlon/zkg.index
@@ -1,0 +1,1 @@
+https://github.com/sfinlon/cif-zeek


### PR DESCRIPTION
I finally remembered that I told Seth (https://github.com/zeek/zeek/pull/439) that I would make this an external package so that it didn't need to be included as part of the core code.