### PR TITLE
Renamed endace/bro-dag to endace/zeek-dag

### DIFF
--- a/endace/bro-pkg.index
+++ b/endace/bro-pkg.index
@@ -1,1 +1,1 @@
-https://github.com/endace/bro-dag
+https://github.com/endace/zeek-dag


### PR DESCRIPTION
Renamed endace/bro-dag to endace/zeek-dag
zeek-dag has been updated to v0.4 for zeek 4.0/4.1
