### PR TITLE
Aggregate-push metadata periodically and when we push to master

### DIFF
--- a/.github/workflows/aggregator.yml
+++ b/.github/workflows/aggregator.yml
@@ -1,0 +1,20 @@
+name: Aggregate package source
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 */3 * * *'
+
+jobs:
+  aggregate-metadata:
+    runs-on: ubuntu-20.04
+    env:
+      ZKG_DEFAULT_SOURCE: https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+    steps:
+      - name: zkg refresh
+        run: |
+          git config --global user.name "Zeek Package Bot"
+          git config --global user.email "package-bot@zeek.org"
+          pip3 install zkg && zkg -vvv refresh --aggregate --fail-on-aggregate-problems --push


### PR DESCRIPTION
This runs "zkg -vvv refresh --aggregate --push" to update the aggregate.meta file. (As of zkg 2.10.0 the "-vvv" shows which packages changed and whether a commit actually happened.)

You can see an example of a run in my fork: https://github.com/ckreibich/packages/runs/2899041571?check_suite_focus=true

I made up a name and email address for the author of the commits ... let me know if we have anything more suitable.