### PR TITLE
Added package to compute coefficient of variation

### DIFF
--- a/thibaultbl/zkg.index
+++ b/thibaultbl/zkg.index
@@ -1,0 +1,1 @@
+https://github.com/thibaultbl/variation_coefficient


### PR DESCRIPTION
This package is a new Sumstats::Calculation to compute coefficient of variation (standard_deviation / average), sort of relative standard deviation.

Reference
[https://en.wikipedia.org/wiki/Coefficient_of_variation](https://en.wikipedia.org/wiki/Coefficient_of_variation)