### PR TITLE
add http-header-count script

### DIFF
--- a/elcabezzonn/zkg.index
+++ b/elcabezzonn/zkg.index
@@ -1,0 +1,1 @@
+https://github.com/elcabezzonn/http-header-count


### PR DESCRIPTION
This is a modification to the header-names.zeek script. The objective of this script is to count the headers of the http request from the originator. This could help with identifying anomalous activity in your environment. For example, a few years ago there was malware (forgot which one) that leveraged a powershell cmldet ( forget which one sorry!) that downloaded an executable from attacker controlled infrastructure. The http header count was always two and combining it with a trans depth of 1 meaning non pipelined request, no referrer and filetype dos exec, it allowed you to query for interesting results. Other use cases also exist for combining the header count with other http fields. 