### PR TITLE
add smb2-remote-file-copy script

### DIFF
--- a/elcabezzonn/zkg.index
+++ b/elcabezzonn/zkg.index
@@ -1,1 +1,2 @@
 https://github.com/elcabezzonn/http-header-count
+https://github.com/elcabezzonn/smb2-remote-file-copy


### PR DESCRIPTION
This script identifies files that are copied to a remote host over smb2. It does this by looking at the number in the request$disposition field in the smb2 create request packet. If the number is 2 (FILE_CREATE), 4 (FILE_OVERWRITE) or 5 (FILE_OVERWRITE_IF), it will trigger and write to the notice.log with the file name that may have been copied over.