### PR TITLE
Added parser for Genisys to CISA ICSNPP package index

### DIFF
--- a/cisagov/zkg.index
+++ b/cisagov/zkg.index
@@ -3,5 +3,6 @@ https://github.com/cisagov/icsnpp-bsap
 https://github.com/cisagov/icsnpp-dnp3
 https://github.com/cisagov/icsnpp-enip
 https://github.com/cisagov/icsnpp-ethercat
+https://github.com/cisagov/icsnpp-genisys
 https://github.com/cisagov/icsnpp-modbus
 https://github.com/cisagov/icsnpp-opcua-binary


### PR DESCRIPTION
Added icsnpp-genisys (https://github.com/cisagov/icsnpp-genisys) parser for Genisys over TCP/IP to CISA ICSNPP packages index.
