### PR TITLE
Add CVE-2022-26809 detector

### DIFF
--- a/corelight/zkg.index
+++ b/corelight/zkg.index
@@ -39,3 +39,4 @@ https://github.com/corelight/zeek-spicy-openvpn
 https://github.com/corelight/zeek-spicy-wireguard
 https://github.com/corelight/CVE-2022-24491
 https://github.com/corelight/CVE-2022-24497
+https://github.com/corelight/cve-2022-26809


### PR DESCRIPTION
Repo will be made public tomorrow (2022-05-17) when the blog is released.