### PR TITLE
Added fdekeers' Spicy-based IGMP packet analyzer package

### DIFF
--- a/fdekeers/zkg.index
+++ b/fdekeers/zkg.index
@@ -1,0 +1,1 @@
+https://github.com/zeek-plugins/igmp


### PR DESCRIPTION
Hi,

I created an IGMP packet analyzer, based on Spicy.
The package is available in this repository: https://github.com/zeek-plugins/igmp
The IGMP protocol is described in [RFC 1112](https://datatracker.ietf.org/doc/html/rfc1112) (IGMPv1), [RFC 2236](https://datatracker.ietf.org/doc/html/rfc2236) (IGMPv2) and [RFC 3376](https://datatracker.ietf.org/doc/html/rfc3376) (IGMPv3).

Thanks for considering.