### PR TITLE
Added icsnpp-s7comm parser

### DIFF
--- a/cisagov/zkg.index
+++ b/cisagov/zkg.index
@@ -6,3 +6,4 @@ https://github.com/cisagov/icsnpp-ethercat
 https://github.com/cisagov/icsnpp-genisys
 https://github.com/cisagov/icsnpp-modbus
 https://github.com/cisagov/icsnpp-opcua-binary
+https://github.com/cisagov/icsnpp-s7comm


### PR DESCRIPTION
Added icsnpp-s7comm parser to cisagov parser list (https://github.com/cisagov/icsnpp-s7comm)