### PR TITLE
Add Shodan InternetDB package

### DIFF
--- a/shodan/zkg.index
+++ b/shodan/zkg.index
@@ -1,0 +1,1 @@
+https://gitlab.com/shodan-public/shodan-zeek/


### PR DESCRIPTION
The [InternetDB integration](https://gitlab.com/shodan-public/shodan-zeek) adds open ports, vulnerabilities and other information to IPs so users can make decisions based on what the remote IP is running. It adds 2 new methods:

* InternetDB::lookup_internetdb_api
* InternetDB::lookup_internetdb_sqlite

``InternetDB::lookup_internetdb_api`` uses the free [InternetDB API](https://internetdb.shodan.io) that is available to everybody and doesn't require an API key. However, depending on the volume of network traffic it can be a problem to use an external API so for environments that need higher throughput they can use the ``InternetDB::lookup_internetdb_sqlite`` method which requires a local SQLite version of InternetDB. The SQLite version is only available to [enterprise](https://enterprise.shodan.io) users of Shodan.