### PR TITLE
corelight: Add ZeekJS

### DIFF
--- a/corelight/zkg.index
+++ b/corelight/zkg.index
@@ -28,6 +28,7 @@ https://github.com/corelight/zeek-notice-telegram
 https://github.com/corelight/zeek-openvpn
 https://github.com/corelight/zeek-quic
 https://github.com/corelight/zeek-xor-exe-plugin
+https://github.com/corelight/zeekjs
 https://github.com/corelight/zerologon
 https://github.com/corelight/ztest
 https://github.com/corelight/CVE-2021-42292


### PR DESCRIPTION
From the ZeekJS repo:

>  Besides Fedora, Ubuntu 22.10 and Debian (testing/bookworm) ship with a recent libnode-dev package that can be used to compile/link ZeekJS. This means there are now three distributions on which ZeekJS works without the need to compile the Node.js shared library manually.
>
> Add a zkg.meta file to allow installing ZeekJS via the zkg package manager.