### PR TITLE
Add 3 zeek scripts to log the gateway IP, Detect DoH servers, and add arp.log

### DIFF
--- a/stratosphereips/zkg.index
+++ b/stratosphereips/zkg.index
@@ -1,1 +1,4 @@
 https://github.com/stratosphereips/zeek-package-IRC
+https://github.com/stratosphereips/zeek-package-detect-DoH
+https://github.com/stratosphereips/zeek-package-ARP
+https://github.com/stratosphereips/zeek-package-log-gateway-IP

--- a/stratosphereips/zkg.index
+++ b/stratosphereips/zkg.index
@@ -1,1 +1,1 @@
-https://github.com/stratosphereips/IRC-Zeek-package
+https://github.com/stratosphereips/zeek-package-IRC


### PR DESCRIPTION
I added the following zeek scripts

https://github.com/stratosphereips/zeek-package-detect-DoH
https://github.com/stratosphereips/zeek-package-ARP
https://github.com/stratosphereips/zeek-package-log-gateway-IP

And updated the link to the stratosphereips IRC plugin 
