### PR TITLE
Added icsnpp-synchrophasor, parser for Synchrophasor Data Transfer for Power Systems (C37.118)

### DIFF
--- a/cisagov/zkg.index
+++ b/cisagov/zkg.index
@@ -7,3 +7,4 @@ https://github.com/cisagov/icsnpp-genisys
 https://github.com/cisagov/icsnpp-modbus
 https://github.com/cisagov/icsnpp-opcua-binary
 https://github.com/cisagov/icsnpp-s7comm
+https://github.com/cisagov/icsnpp-synchrophasor


### PR DESCRIPTION
Updated package index adding added icsnpp-synchrophasor, parser for Synchrophasor Data Transfer for Power Systems (C37.118).

https://github.com/cisagov/icsnpp-synchrophasor