### PR TITLE
Remove testimony plugin from sirinsoftware/zkg.index

### DIFF
--- a/sirinsoftware/zkg.index
+++ b/sirinsoftware/zkg.index
@@ -1,1 +1,0 @@
-https://github.com/MalakhatkoVadym/zeek-testimony-plugin.git


### PR DESCRIPTION
That repository doesn't exist anymore, resulting in HTTP 404 and causing the aggregate job to report a failure.