### PR TITLE
Deprecate Binpac OpenVPN analyzer.

### DIFF
--- a/corelight/zkg.index
+++ b/corelight/zkg.index
@@ -25,7 +25,6 @@ https://github.com/corelight/zeek-jpeg
 https://github.com/corelight/zeek-long-connections
 https://github.com/corelight/zeek-macho
 https://github.com/corelight/zeek-notice-telegram
-https://github.com/corelight/zeek-openvpn
 https://github.com/corelight/zeek-quic
 https://github.com/corelight/zeek-xor-exe-plugin
 https://github.com/corelight/zeekjs


### PR DESCRIPTION
Removing an unsupported analyzer.