### PR TITLE
add package source nttcom

### DIFF
--- a/nttcom/zkg.index
+++ b/nttcom/zkg.index
@@ -1,0 +1,2 @@
+https://github.com/nttcom/zeek-parser-CCLinkFieldBasic
+https://github.com/nttcom/zeek-parser-CCLinkField-CCLinkControl


### PR DESCRIPTION
Creation of zeek plug-ins for the CC-Link family of protocols most used in Japanese PLCs.