### PR TITLE
Adapt to new repo name of package

### DIFF
--- a/tenzir/zkg.index
+++ b/tenzir/zkg.index
@@ -1,2 +1,2 @@
 https://github.com/tenzir/zeek-mac-ages
-https://github.com/tenzir/zeek-vast
+https://github.com/tenzir/zeek-tenzir


### PR DESCRIPTION
This PR udpates the name of our <https://github.com/tenzir/zeek-tenzir> package after we recently [renamed VAST to Tenzir](https://docs.tenzir.com/blog/vast-to-tenzir).
