### PR TITLE
add package sources to nttcom

### DIFF
--- a/nttcom/zkg.index
+++ b/nttcom/zkg.index
@@ -1,2 +1,7 @@
 https://github.com/nttcom/zeek-parser-CCLinkField-CCLinkControl
 https://github.com/nttcom/zeek-parser-CCLinkFieldBasic
+https://github.com/nttcom/zeek-parser-CIFS-COM
+https://github.com/nttcom/zeek-parser-DHCPv6-COM
+https://github.com/nttcom/zeek-parser-DHCPv4-COM
+https://github.com/nttcom/zeek-parser-CIFS-NBNS-COM
+https://github.com/nttcom/zeek-parser-SSDP-COM

--- a/nttcom/zkg.index
+++ b/nttcom/zkg.index
@@ -5,3 +5,4 @@ https://github.com/nttcom/zeek-parser-DHCPv6-COM
 https://github.com/nttcom/zeek-parser-DHCPv4-COM
 https://github.com/nttcom/zeek-parser-CIFS-NBNS-COM
 https://github.com/nttcom/zeek-parser-SSDP-COM
+https://github.com/nttcom/zeek-parser-Bacnet


### PR DESCRIPTION
Packages used as zeek plug-ins for protocols used in Japanese PLCs.