### PR TITLE
ICSNPP Profinet IO CM release

### DIFF
--- a/cisagov/zkg.index
+++ b/cisagov/zkg.index
@@ -8,3 +8,4 @@ https://github.com/cisagov/icsnpp-modbus
 https://github.com/cisagov/icsnpp-opcua-binary
 https://github.com/cisagov/icsnpp-s7comm
 https://github.com/cisagov/icsnpp-synchrophasor
+https://github.com/cisagov/icsnpp-profinet-io-cm


### PR DESCRIPTION
Update to support installation of the cisagov ICSNPP Profinet IO CM parser via zkg