### PR TITLE
Add corelight/zeek-nats-log-writer

### DIFF
--- a/corelight/zkg.index
+++ b/corelight/zkg.index
@@ -35,6 +35,7 @@ https://github.com/corelight/zeek-gozi-detector
 https://github.com/corelight/zeek-jpeg
 https://github.com/corelight/zeek-long-connections
 https://github.com/corelight/zeek-macho
+https://github.com/corelight/zeek-nats-log-writer
 https://github.com/corelight/zeek-notice-telegram
 https://github.com/corelight/zeek-quic
 https://github.com/corelight/zeek-spicy-facefish


### PR DESCRIPTION
This provides a Zeek log writer for the NATS.io messaging system.