### PR TITLE
HASSH repo - new home at Corelight

### DIFF
--- a/corelight/zkg.index
+++ b/corelight/zkg.index
@@ -20,6 +20,7 @@ https://github.com/corelight/CVE-2022-3602
 https://github.com/corelight/detect-ransomware-filenames
 https://github.com/corelight/ExtendIntel
 https://github.com/corelight/got_zoom
+https://github.com/corelight/hassh
 https://github.com/corelight/http-stalling-detector
 https://github.com/corelight/icannTLD
 https://github.com/corelight/json-streaming-logs

--- a/salesforce/zkg.index
+++ b/salesforce/zkg.index
@@ -1,4 +1,3 @@
 https://github.com/salesforce/bro-sysmon
 https://github.com/salesforce/GQUIC_Protocol_Analyzer
-https://github.com/salesforce/hassh
 https://github.com/salesforce/ja3


### PR DESCRIPTION
As per discussions with Caleb at SFDC, the HASSH repo has been re-written and is now being maintained at Corelight instead of at Salesforce. 