### PR TITLE
Drop `zeek-test-package`

### DIFF
--- a/jsiwek/zkg.index
+++ b/jsiwek/zkg.index
@@ -1,3 +1,2 @@
 https://github.com/jsiwek/zeek-cryptomining
 https://github.com/jsiwek/zeek-print-log-info
-https://github.com/jsiwek/zeek-test-package


### PR DESCRIPTION
This package was added as a test package during zkg development and has was never intended for user consumption.