### PR TITLE
Added reference for the CISA ICSNPP GE-SRTP zeek parser

### DIFF
--- a/cisagov/zkg.index
+++ b/cisagov/zkg.index
@@ -10,3 +10,4 @@ https://github.com/cisagov/icsnpp-opcua-binary
 https://github.com/cisagov/icsnpp-profinet-io-cm
 https://github.com/cisagov/icsnpp-s7comm
 https://github.com/cisagov/icsnpp-synchrophasor
+https://github.com/cisagov/icsnpp-ge-srtp.git

--- a/cisagov/zkg.index
+++ b/cisagov/zkg.index
@@ -4,10 +4,10 @@ https://github.com/cisagov/icsnpp-bsap
 https://github.com/cisagov/icsnpp-dnp3
 https://github.com/cisagov/icsnpp-enip
 https://github.com/cisagov/icsnpp-ethercat
+https://github.com/cisagov/icsnpp-ge-srtp.git
 https://github.com/cisagov/icsnpp-genisys
 https://github.com/cisagov/icsnpp-modbus
 https://github.com/cisagov/icsnpp-opcua-binary
 https://github.com/cisagov/icsnpp-profinet-io-cm
 https://github.com/cisagov/icsnpp-s7comm
 https://github.com/cisagov/icsnpp-synchrophasor
-https://github.com/cisagov/icsnpp-ge-srtp.git


### PR DESCRIPTION
Updated to zkg.index include new parser ICSNPP GE-SRTP located at: https://github.com/cisagov/icsnpp-ge-srtp.git