### PR TITLE
Add HART-IP and Omron FINS for cisagov

### DIFF
--- a/cisagov/zkg.index
+++ b/cisagov/zkg.index
@@ -6,7 +6,9 @@ https://github.com/cisagov/icsnpp-enip
 https://github.com/cisagov/icsnpp-ethercat
 https://github.com/cisagov/icsnpp-ge-srtp.git
 https://github.com/cisagov/icsnpp-genisys
+https://github.com/cisagov/icsnpp-hart-ip
 https://github.com/cisagov/icsnpp-modbus
+https://github.com/cisagov/icsnpp-omron-fins
 https://github.com/cisagov/icsnpp-opcua-binary
 https://github.com/cisagov/icsnpp-profinet-io-cm
 https://github.com/cisagov/icsnpp-s7comm


### PR DESCRIPTION
CISA has recently released two ICSNPP protocol parsers installable with zkg. This PR adds them as packages:
- HART-IP
- Omron FINS