### PR TITLE
Add Emerson ROC+ Parser

### DIFF
--- a/cisagov/zkg.index
+++ b/cisagov/zkg.index
@@ -4,12 +4,13 @@ https://github.com/cisagov/icsnpp-bsap
 https://github.com/cisagov/icsnpp-dnp3
 https://github.com/cisagov/icsnpp-enip
 https://github.com/cisagov/icsnpp-ethercat
-https://github.com/cisagov/icsnpp-ge-srtp.git
+https://github.com/cisagov/icsnpp-ge-srtp
 https://github.com/cisagov/icsnpp-genisys
 https://github.com/cisagov/icsnpp-hart-ip
 https://github.com/cisagov/icsnpp-modbus
 https://github.com/cisagov/icsnpp-omron-fins
 https://github.com/cisagov/icsnpp-opcua-binary
 https://github.com/cisagov/icsnpp-profinet-io-cm
+https://github.com/cisagov/icsnpp-roc-plus
 https://github.com/cisagov/icsnpp-s7comm
 https://github.com/cisagov/icsnpp-synchrophasor


### PR DESCRIPTION
This request adds the newly released Emerson ROC+ parser to the packages list and includes a minor change to the GE-SRTP link to make it consistent with all other links.