### PR TITLE
Ubuntu 20.04 is EOL, so update the aggregator's runner.

### DIFF
--- a/.github/workflows/aggregator.yml
+++ b/.github/workflows/aggregator.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   aggregate-metadata:
     if: github.repository == 'zeek/packages'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       ZKG_DEFAULT_SOURCE: https://zeek-bot:${{ secrets.ZEEK_BOT_TOKEN }}@github.com/${{ github.repository }}
     steps:


### PR DESCRIPTION
Workflows on the old version no longer run, see e.g. [here](https://github.com/zeek/packages/actions/runs/14757881199).