### PR TITLE
Add Zeek package: unauthorized SMB usage detector

### DIFF
--- a/Cynthianfatkid/zkg.index
+++ b/Cynthianfatkid/zkg.index
@@ -1,0 +1,1 @@
+https://github.com/Cynthianfatkid/zeek-unauthorized-smb-usage


### PR DESCRIPTION
Adds a new Zeek package to detect unauthorized SMB/SMB2 connections based on a user-defined allowlist. Alerts via notice framework and logs to a custom stream.