### PR TITLE
Added :  Zeek package that decodes RFC 2047 MIME encoded-words in SMTP.log Subjects

### DIFF
--- a/initconf/zkg.index
+++ b/initconf/zkg.index
@@ -18,3 +18,4 @@ https://github.com/initconf/vnc-scanner
 https://github.com/initconf/ws-discovery-dos
 https://github.com/initconf/2024-09-cups-linux-rce
 https://github.com/initconf/misp_intel.git
+https://github.com/initconf/smtp-rfc2047-decoding.git


### PR DESCRIPTION
Zeek package that decodes RFC 2047 MIME encoded-words in SMTP Subject headers and adds the decoded value to smtp.log as decoded_subject.