### PR TITLE
Add Flowtriq DDoS detection package

### DIFF
--- a/Flowtriq/zkg.index
+++ b/Flowtriq/zkg.index
@@ -1,0 +1,1 @@
+https://github.com/Flowtriq/zeek-flowtriq


### PR DESCRIPTION
## Summary

- Registers the [zeek-flowtriq](https://github.com/Flowtriq/zeek-flowtriq) package in the Zeek package index
- The package detects volumetric DDoS attacks (SYN flood, UDP flood, ICMP flood) and sends structured JSON alerts to the [Flowtriq](https://flowtriq.com) traffic analytics platform via webhook
- Pure Zeek scripts, no native plugins or build step required; depends on Zeek 5.0+