### PR TITLE
Move XDP zeek into zeek org

### DIFF
--- a/evantypanski/zkg.index
+++ b/evantypanski/zkg.index
@@ -1,3 +1,2 @@
 https://github.com/evantypanski/spicy-nats
 https://github.com/evantypanski/spicy-redis
-https://github.com/evantypanski/xdp-zeek

--- a/zeek/zkg.index
+++ b/zeek/zkg.index
@@ -18,3 +18,4 @@ https://github.com/zeek/zeek-more-hashes
 https://github.com/zeek/zeek-netmap
 https://github.com/zeek/zeek-packet-source-udp
 https://github.com/zeek/zeek-perf-support
+https://github.com/zeek/zeek-xdp


### PR DESCRIPTION
I moved the [XDP Zeek repo](https://github.com/zeek/xdp-zeek) to the Zeek org, so this moves it in the package index, too.