### PR TITLE
Added repo ja4-zeek-scripts

### DIFF
--- a/foxio/zkg.index
+++ b/foxio/zkg.index
@@ -1,1 +1,2 @@
 https://github.com/FoxIO-LLC/ja4
+https://github.com/FoxIO-LLC/ja4-zeek-scripts


### PR DESCRIPTION
/ja4 has been upgraded from Zeek scripts to Zeek Plugins + Scripts and now requires Zeek v7+

I created /ja4-zeek-scripts for those who want a scripts-only copy of JA4+ that supports Zeek v5+